### PR TITLE
Fix error with recursion detection

### DIFF
--- a/post-commit
+++ b/post-commit
@@ -10,7 +10,7 @@ git --no-pager log --no-merges --format="### %s%d%n>%aD%n%n>Author: %aN (%aE)%n%
 # prevent recursion!
 # since a 'commit --amend' will trigger the post-commit script again
 # we have to check if the changelog file has changed or not
-res=$(git status --porcelain | grep $OUTPUT_FILE | wc -l)
+res=$(git status --porcelain | grep ".\ $OUTPUT_FILE$" | wc -l)
 if [ "$res" -gt 0 ]; then
   git add $OUTPUT_FILE
   git commit --amend


### PR DESCRIPTION
If you are having a CHANGELOG.md file in a subfolder of your project, the post-commit hook would get stuck in a loop.
This commit introduces a simple regex that only checks for the CHANGELOG.md file in the project root directory.